### PR TITLE
added flag to require display name

### DIFF
--- a/config.js
+++ b/config.js
@@ -275,7 +275,7 @@ var config = {
     //
 
     // Require users to always specify a display name.
-    // requireDisplayName: true,
+    requireDisplayName: true,
 
     // Whether to use a welcome page or not. In case it's false a random room
     // will be joined when no room is specified.

--- a/config.js
+++ b/config.js
@@ -275,7 +275,7 @@ var config = {
     //
 
     // Require users to always specify a display name.
-    requireDisplayName: true,
+    // requireDisplayName: true,
 
     // Whether to use a welcome page or not. In case it's false a random room
     // will be joined when no room is specified.
@@ -315,7 +315,7 @@ var config = {
     // enableCalendarIntegration: false,
 
     // When 'true', it shows an intermediate page before joining, where the user can configure their devices.
-    // prejoinPageEnabled: false,
+    prejoinPageEnabled: false,
 
     // If true, shows the unsafe room name warning label when a room name is
     // deemed unsafe (due to the simplicity in the name) and a password is not


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
in order to show the prejoin page, we need to allow the options to show the `<PreJoin>` component. this required that we have a particular config such as `requireDisplayName` which does match with what we are encouraging at this time. there are other options that can be explored as well